### PR TITLE
Added Nemo Configuration ignoreBrowserCapabilities

### DIFF
--- a/setup/index.js
+++ b/setup/index.js
@@ -57,7 +57,7 @@ Setup.prototype = {
 
     function getCapabilities() {
       //exception handling
-      if (!nemoData.ignoreTargetBrowserCheck && !webdriver.Capabilities[tgtBrowser]) {
+      if (!nemoData.ignoreBrowserCapabilities && !webdriver.Capabilities[tgtBrowser]) {
         throw new TypeError('You have specified ' + tgtBrowser + ' which is an invalid browser option');
       }
       caps = new webdriver.Capabilities();
@@ -68,7 +68,7 @@ Setup.prototype = {
         });
       }
 
-      if (!nemoData.ignoreTargetBrowserCheck) {
+      if (!nemoData.ignoreBrowserCapabilities) {
         caps.merge(webdriver.Capabilities[tgtBrowser]());
       }
 


### PR DESCRIPTION
For making memo work with the perfecto mobile test suite I needed to add the option to ignore the 'valid browser check' and also disable adding of default capabilities.
PerfectoMobile has its own selenium.jar and is configured via the "serverCaps" option of nemoData config.

To disable the 'valid browser check' configure nemoData like this:
"nemoData": {
    "ignoreBrowserCapabilities": true
}
