### PR TITLE
Features: external.driver and shortstop handlers prepend

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -11,16 +11,19 @@ const error = debug('nemo:error');
 log.log = console.log.bind(console);
 error.log = console.error.bind(console);
 
-module.exports = function Configure(_basedir, _configOverride) {
+module.exports = function Configure(_basedir, _configOverride, _handlersOverride) {
   log('_basedir %s, _configOverride %o', _basedir, _configOverride);
-  let basedir, configOverride;
+  let basedir, configOverride, handlersOverride;
   //settle arguments
   basedir = arguments.length && typeof arguments[0] === 'string' ? arguments[0] : process.env.nemoBaseDir || undefined;
   configOverride = !basedir && arguments.length && typeof arguments[0] === 'object' ? arguments[0] : undefined;
   configOverride = !configOverride && arguments.length && arguments[1] && typeof arguments[1] === 'object' ? arguments[1] : configOverride;
   configOverride = !configOverride ? {} : configOverride;
+  handlersOverride = arguments.length && typeof arguments[0] === 'boolean' ? arguments[0] : undefined;
+  handlersOverride = !handlersOverride && arguments.length && typeof arguments[1] === 'boolean' ? arguments[1] : handlersOverride;
+  handlersOverride = !handlersOverride && arguments.length && typeof arguments[2] === 'boolean' ? arguments[2] : handlersOverride;
 
-  log('basedir %s, configOverride %o', basedir, configOverride);
+  log('basedir %s, configOverride %o, handlersOverride %s', basedir, configOverride, handlersOverride);
 
   let prom = Promiz();
 
@@ -29,6 +32,7 @@ module.exports = function Configure(_basedir, _configOverride) {
   let envdata = envToJSON('data');
   let envdriver = envToJSON('driver');
   let envplugins = envToJSON('plugins');
+
   let confitOptions = {
     protocols: {
       path: handlers.path(basedir),
@@ -44,6 +48,23 @@ module.exports = function Configure(_basedir, _configOverride) {
       }
     }
   };
+  if (handlersOverride) {
+    confitOptions = {
+      protocols: {
+        _path: handlers.path(basedir),
+        _env: handlers.env(),
+        _file: handlers.file(basedir),
+        _base64: handlers.base64(),
+        _require: handlers.require(basedir),
+        _exec: handlers.exec(basedir),
+        _glob: handlers.glob(basedir),
+        _argv: function argHandler(val) {
+          let argv = yargs.argv;
+          return argv[val] || '';
+        }
+      }
+    };
+  }
   if (basedir) {
     confitOptions.basedir = path.join(basedir, 'config');
   }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -100,31 +100,35 @@ function Driver() {
         }
       }
 
-      try {
-
-        var builder = new webdriver.Builder();
-        if (builders !== undefined) {
-          Object.keys(builders).forEach(function (bldr) {
-            builder = builder[bldr].apply(builder, builders[bldr]);
-          });
+      if (typeof driverProps == 'function') {
+        driver = driverProps();
+      } else {
+        try {
+          var builder = new webdriver.Builder();
+          if (builders !== undefined) {
+            Object.keys(builders).forEach(function (bldr) {
+              builder = builder[bldr].apply(builder, builders[bldr]);
+            });
+          }
+          if (serverUrl !== undefined && !(builders && builders.usingServer)) {
+            builder = builder.usingServer(getServer());
+          }
+          if (tgtBrowser !== undefined && !(builders && builders.forBrowser)) {
+            builder = builder.withCapabilities(getCapabilities());
+          }
+          if (proxyDetails !== undefined) {
+            builder = builder.setProxy(getProxy());
+          }
+          log('builder FINAL', builder);
+          driver = builder.build();
+        } catch (err) {
+          error('Encountered an error during driver setup: %s', err);
+          errorObject = err;
+          callback(errorObject);
+          return;
         }
-        if (serverUrl !== undefined && !(builders && builders.usingServer)) {
-          builder = builder.usingServer(getServer());
-        }
-        if (tgtBrowser !== undefined && !(builders && builders.forBrowser)) {
-          builder = builder.withCapabilities(getCapabilities());
-        }
-        if (proxyDetails !== undefined) {
-          builder = builder.setProxy(getProxy());
-        }
-        log('builder FINAL', builder);
-        driver = builder.build();
-      } catch (err) {
-        error('Encountered an error during driver setup: %s', err);
-        errorObject = err;
-        callback(errorObject);
-        return;
       }
+
       driver.getSession().then(function () {
         callback(null, driver);
       }).catch(function (err) {
@@ -134,4 +138,5 @@ function Driver() {
     }
   };
 }
+
 module.exports = Driver;

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -113,4 +113,14 @@ describe('@constructor@', function () {
         return assert(nemo.driver);
       });
   });
+  it('@handlerOverride@ prepends handler keys with _', function () {
+    delete process.env.nemoBaseDir;
+    process.env.HANDLER_OVERRIDE_DATA = 'Alice';
+    return Nemo.Configure({driver: {browser: 'phantomjs'}, data: {ask: '_env:HANDLER_OVERRIDE_DATA'}}, true).then(function (confit) {
+      return Nemo(confit);
+    })
+      .then(function (nemo) {
+        assert(nemo.data.ask === 'Alice')
+      });
+  });
 });

--- a/test/override.js
+++ b/test/override.js
@@ -55,4 +55,24 @@ describe('@override@', function () {
       });
     });
   });
+  it('@driverFunction@ overrides other driver abstractions', function (done) {
+    process.env.nemoBaseDir = __dirname;
+
+    Nemo({
+      driver: function () {
+        const {Builder} = require('selenium-webdriver');
+        return new Builder().forBrowser('phantomjs').build()
+      },
+      data: {
+        baseUrl: 'http://www.ebay.com'
+      }
+    }, function (err, nemo) {
+      nemo.driver.getCapabilities().then(function (caps) {
+        assert.notEqual(caps.browserName, 'firefox');
+        nemo.driver.quit();
+        done();
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
## Shortstop Handlers prepend

Passing new boolean argument to `Nemo.Configure` will create prepended shortstop handler keys. This is useful in situations such as `krakenjs/nemo` where the configuration is consumed twice.

## External Driver

Allow an external driver to be passed in. allows full driver customization, not constrained by the internal create method.

Specify via config as:

```js
{
  "driver": "require:./myDriver"
}
...
```

Example of `myDriver.js`:
```js
const {Builder} = require('selenium-webdriver');
const {Options} = require('selenium-webdriver/chrome');

module.exports = function () {
  let copts = new Options().setMobileEmulation({deviceName: 'Nexus 5X'}).setChromeBinaryPath('/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome');
  let driver = new Builder()
    .forBrowser('chrome')
    .setChromeOptions(
      copts)
    .build();
  return driver;
}
```